### PR TITLE
Fix error dans reducer structures

### DIFF
--- a/src/reducers/structuresReducer.js
+++ b/src/reducers/structuresReducer.js
@@ -9,7 +9,8 @@ export default function structures(state = [], action) {
       return {
         ...state,
         loading: false,
-        items: action.structures
+        items: action.structures,
+        error: false
       };
     case 'GETALL_FAILURE':
       return {
@@ -23,7 +24,8 @@ export default function structures(state = [], action) {
     case 'GET_STRUCTURES_RECRUTEMENT_SUCCESS':
       return {
         ...state,
-        avancement: action.result
+        avancement: action.result,
+        error: false
       };
     case 'GET_STRUCTURES_RECRUTEMENT_FAILURE':
       return {


### PR DESCRIPTION
Le pb était que error valait token expired après expiration du login. Du coup, au prochain success le error n'était pas remis à false mais restait avec la valeur token expired .
La condition !structures.error n'était pas Ok pour que l'affichage de la liste se fasse